### PR TITLE
Use CDNJS in all JS and CSS links to allow faster page loading

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -9,18 +9,18 @@
     <link id="favicon" rel="icon" href="https://github.com/tamlok/viki/raw/master/resources/viki.ico">
 
     <!-- Bootstrap CSS -->
-    <link href="https://cdn.bootcss.com/twitter-bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css">
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jstree@3.3.7/dist/themes/default/style.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.7/themes/default/style.min.css">
 
-    <link href="css/highlightjs.css" rel="stylesheet">
-    <link href="css/viki.css" rel="stylesheet">
-    <link href="css/custom.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/highlightjs.css">
+    <link rel="stylesheet" href="css/viki.css">
+    <link rel="stylesheet" href="css/custom.css">
 
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-    <script src="https://cdn.bootcss.com/jquery/3.3.1/jquery.min.js"></script>
-    <script src="https://cdn.bootcss.com/popper.js/1.14.3/umd/popper.min.js"></script>
-    <script src="https://cdn.bootcss.com/twitter-bootstrap/4.1.3/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/esm/popper.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.min.js"></script>
 
     <!--
     <script src="https://cdn.bootcss.com/highlight.js/9.13.1/highlight.min.js"></script>
@@ -45,13 +45,13 @@
     <!--
     <script src="https://cdn.bootcss.com/mermaid/8.0.0-rc.8/mermaid.min.js"></script>
     -->
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@8.0.0-rc.8/dist/mermaid.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/8.0.0/mermaid.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/raphael/2.2.7/raphael.min.js"></script>
     <!--
     <script src="https://cdn.bootcss.com/flowchart/1.11.3/flowchart.min.js"></script>
     -->
-    <script src="https://cdn.jsdelivr.net/npm/flowchart.js@1.11.3/release/flowchart.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowchart/1.11.3/flowchart.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/skins/default.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/wavedrom.min.js"></script>
@@ -61,7 +61,7 @@
     <script src="http://s.plantuml.com/zopfli.raw.min.js"></script>
     -->
 
-    <script src="https://cdn.jsdelivr.net/npm/jstree@3.3.7/dist/jstree.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.7/jstree.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_HTMLorMML" async></script>
 

--- a/viki.html
+++ b/viki.html
@@ -9,18 +9,18 @@
     <link id="favicon" rel="icon" href="https://github.com/tamlok/viki/raw/master/resources/viki.ico">
 
     <!-- Bootstrap CSS -->
-    <link href="https://cdn.bootcss.com/twitter-bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css">
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jstree@3.3.7/dist/themes/default/style.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.7/themes/default/style.min.css">
 
-    <link href="css/highlightjs.css" rel="stylesheet">
-    <link href="css/viki.css" rel="stylesheet">
-    <link href="css/custom.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/highlightjs.css">
+    <link rel="stylesheet" href="css/viki.css">
+    <link rel="stylesheet" href="css/custom.css">
 
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-    <script src="https://cdn.bootcss.com/jquery/3.3.1/jquery.min.js"></script>
-    <script src="https://cdn.bootcss.com/popper.js/1.14.3/umd/popper.min.js"></script>
-    <script src="https://cdn.bootcss.com/twitter-bootstrap/4.1.3/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/esm/popper.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.min.js"></script>
 
     <!--
     <script src="https://cdn.bootcss.com/highlight.js/9.13.1/highlight.min.js"></script>
@@ -45,13 +45,13 @@
     <!--
     <script src="https://cdn.bootcss.com/mermaid/8.0.0-rc.8/mermaid.min.js"></script>
     -->
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@8.0.0-rc.8/dist/mermaid.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/8.0.0/mermaid.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/raphael/2.2.7/raphael.min.js"></script>
     <!--
     <script src="https://cdn.bootcss.com/flowchart/1.11.3/flowchart.min.js"></script>
     -->
-    <script src="https://cdn.jsdelivr.net/npm/flowchart.js@1.11.3/release/flowchart.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowchart/1.11.3/flowchart.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/skins/default.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/wavedrom.min.js"></script>
@@ -61,7 +61,7 @@
     <script src="http://s.plantuml.com/zopfli.raw.min.js"></script>
     -->
 
-    <script src="https://cdn.jsdelivr.net/npm/jstree@3.3.7/dist/jstree.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.7/jstree.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_HTMLorMML" async></script>
 


### PR DESCRIPTION
I suggest using CDNJS everywhere, as it is already used anyways. With this replacement the page loads much faster, for example from my different computers in Russia: 1 second vs. 3-7 seconds (on localhost server). I think that's because it reduces the number of established TLS connections to different CDNs (but I may be wrong here), and maybe Cloudflare is just faster than others.

Also added small cosmetic fixes for consistency.